### PR TITLE
Support multi-column primary keys

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -4,13 +4,21 @@ namespace Recca0120\LaravelErd;
 
 class Helpers
 {
-    public static function getTableName(string $qualifiedKeyName): string
+    public static function getTableName(string|array|null $qualifiedKeyName): ?string
     {
+        if (is_array($qualifiedKeyName)) {
+            return implode('-', $qualifiedKeyName);
+        }
+
         return substr($qualifiedKeyName, 0, strpos($qualifiedKeyName, '.'));
     }
 
-    public static function getColumnName(?string $qualifiedKeyName): ?string
+    public static function getColumnName(string|array|null $qualifiedKeyName): ?string
     {
+        if (is_array($qualifiedKeyName)) {
+            return implode('-', $qualifiedKeyName);
+        }
+
         return $qualifiedKeyName && str_contains($qualifiedKeyName, '.')
             ? substr($qualifiedKeyName, strpos($qualifiedKeyName, '.') + 1)
             : $qualifiedKeyName;

--- a/src/Relation.php
+++ b/src/Relation.php
@@ -48,7 +48,7 @@ class Relation
         return Helpers::getColumnName($this->localKey());
     }
 
-    public function foreignKey(): string
+    public function foreignKey(): string|array
     {
         return $this->attributes['foreign_key'];
     }
@@ -93,7 +93,7 @@ class Relation
     }
 
     /**
-     * @param  string[]  $tables
+     * @param string[] $tables
      */
     public function excludes(array $tables): bool
     {


### PR DESCRIPTION
I have a model that uses https://github.com/topclaudy/compoships and has a primary key based on multiple columns.

`php artisan erd:generate` goes wrong on generating the table- and column name. This fixes the errors by also accepting arrays and converting them to a string.

Tests are OK.

(Beautiful package, thanks for that!)