### PR TITLE
Check if method is relation before invoking

### DIFF
--- a/src/RelationFinder.php
+++ b/src/RelationFinder.php
@@ -55,11 +55,11 @@ class RelationFinder
     private static function getRelationAttributes(Model $model, ReflectionMethod $method): ?array
     {
         try {
-            $return = $method->invoke($model);
-
-            if (! $return instanceof EloquentRelation) {
+            if (! is_subclass_of($method->getReturnType()->getName(), EloquentRelation::class)) {
                 return null;
             }
+            
+            $return = $method->invoke($model);
 
             $type = (new ReflectionClass($return))->getName();
             $related = (new ReflectionClass($return->getRelated()))->getName();


### PR DESCRIPTION
Right now, all methods on a given model is invoked, potentially causing issues. This PR checks if the return type of the method is a subclass og EloquentRelation, before attempting to invoke the function, avoiding calls to methods that are not relations.